### PR TITLE
Add setHeader to ClientRequest

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -795,6 +795,7 @@ declare class http$IncomingMessage extends stream$Readable {
 declare class http$ClientRequest extends stream$Writable {
   flushHeaders(): void;
   abort(): void;
+  setHeader(name: string, value: string | Array<string>): void;
   setTimeout(msecs: number, callback?: Function): void;
   setNoDelay(noDelay?: boolean): void;
   setSocketKeepAlive(enable?: boolean, initialDelay?: number): void;


### PR DESCRIPTION
A `ClientRequest` instance has a `setHeader` method.
